### PR TITLE
Many changes

### DIFF
--- a/display_colors.py
+++ b/display_colors.py
@@ -1,6 +1,21 @@
-#!/usr/bin/python
-""" display_colors.py - Setting colours of files/folders from the commandline.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Usage:
+  display_colors.py [options] <file>...
+  display_colors.py -h, --help
+  display_colors.py --version
 
+Options:
+-c, --color=<color>     Set color. Valid values are: none, gray, green, 
+                        purple, blue, yellow, red, orange.
+
+Set colours of files/folders from the commandline.
+Without "-c" or "--color", the script prints the color of each file.
+If -c is set, the script sets the color of each file to <color>
+"""
+
+"""
 Copyright (c) 2012 Daniel Fairhead <danthedeckie on github>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,26 +36,19 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-------------------
-
-Usage:
-
->>> display_colors.py $filename
-outputs which colour it's been set to.
-
->>> display_colors.py $filename $color
-sets the color.
-
 """
+from docopt import docopt
 from xattr import xattr
 from sys import argv, stderr
 from os.path import exists
 
+__version__ = 1.0
+
 FinderInfo = u'com.apple.FinderInfo'
 
-colors = {'none': 0, 'gray': 2, 'green': 4, 'purple': 6, \
+colors = {'none': 0, 'gray': 2, 'green': 4, 'purple': 6, 
           'blue': 8, 'yellow': 10, 'red': 12, 'orange': 14}
-names  = {0: 'none', 2: 'gray', 4: 'green', 6: 'purple', \
+names  = {0: 'none', 2: 'gray', 4: 'green', 6: 'purple', 
           8: 'blue', 10 : 'yellow', 12 : 'red', 14 : 'orange' }
 
 blank = 32*chr(0)
@@ -48,57 +56,37 @@ blank = 32*chr(0)
 def get(filename):
     try:
         attrs = xattr(filename)
-        color_num = ord(attrs.get(FinderInfo)[9])
-        if color_num > 14:
-            color_num -= 16
+        color_num = ord(attrs.get(FinderInfo)[9]) & 14 
+        # & 14 to mask with "1110" (ie ignore all other bits).
         return names[color_num]
-
     except Exception:
         return names[0]
 
-def set(filename, color=0):
+def set(filename, color):
     attrs = xattr(filename)
     if FinderInfo in attrs:
         previous = attrs[FinderInfo]
     else:
         previous = blank
-
-    new = previous[:9] + chr(colors[color]) + previous[10:]
+    prev_color_extra_bits = ord(previous[9]) & (255-14)
+    # these are all the bits in previous[9] not used for color.
+    new = previous[:9] + chr(colors[color] + prev_color_extra_bits) + previous[10:]
     attrs.set(FinderInfo, new)
     return new
 
 if __name__ == '__main__':
-    argc = len(argv) # why calculate it multiple times?
+    args = docopt(__doc__, version=__version__)
+    color = args['--color']
 
-    if argc == 1:
-        print 'Usage:\n{0} $filename $color\n'.format(argv[0])
-        print 'Where color is one of:'
-        print ', '.join(colors)
-        print '\nOr just {0} $filename to find out what colour a file is.'.format(argv[0]) 
-    elif argc == 2:
-        try:
-            print get(argv[1])
-        except Exception as e:
-            stderr.write(str(e))
-            exit(e.errno)
-    elif argc == 3:
-        try:
-            set(argv[1], argv[2])
-        except KeyError as e:
-            if exists(argv[2]):
-                print '\t'.join([argv[1], get(argv[1])])
-                print '\t'.join([argv[2], get(argv[2])])
-            else:
-                stderr.write('Invalid color: {0}\n'.format(str(e)))
-                stderr.write('Try one of:\n {0}\n'.format(', '.join(colors)))
-                exit(1)
-        except Exception as e:
-            stderr.write(str(e))
-            exit(e.errno)
-    else:
-        if argv[-1] in colors:
-            for filename in argv[1:-1]:
-                set(filename,argv[-1])
+    if color:
+        if color not in colors:
+            print __doc__
         else:
-            for filename in argv[1:]:
-                print '\t'.join([filename,get(filename)])
+            for filename in args['<file>']:
+                set(filename, color)
+    else:
+        if len(args['<file>']) == 1:
+            print get(args['<file>'][0])
+        else:
+            for filename in args['<file>']:
+                    print '\t'.join([filename,get(filename)])


### PR DESCRIPTION
1. use env to determine python bin (it might be in a different location)
2. docopt to parse command line arguments (more readable code)
3. preserve existing bits in attribute when setting color.
4. ignore xattribute bits not used for color when getting color

Regarding 3 and 4: I noticed I had a file where the color was set to 9, and Finder was showing it as blue. The reason is that the color is obviously defined by bits 1-3, and my file had bit0 set. So I rewrote get() and set() to ignore the rest of the bits and preserve them in set().
