### PR TITLE
xattr is defined as requirement, setup.py bug fix.

### DIFF
--- a/finder_colors.py
+++ b/finder_colors.py
@@ -52,10 +52,9 @@ which work pretty much as you'd expect.
 """
 
 from __future__ import print_function
-from xattr import xattr
 from sys import argv, stderr
-
 __version__ = '0.9.3'
+
 
 _FINDER_INFO_TAG = u'com.apple.FinderInfo'
 
@@ -108,6 +107,7 @@ def set(filename, color): # pylint: disable=W0622
 # If this is used as a stand-alone script:
 
 if __name__ == '__main__':
+    from xattr import xattr
 
     def display(pathname):
         ''' display filename\tcolor '''

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     url = 'https://github.com/danthedeckie/finder_colors',
     download_url = 'https://github.com/danthedeckie/finder_colors/tarball/' + __version__,
     keywords = ['OSX', 'OS X', 'Finder', 'Colors', 'Utility', 'Colours'],
+    install_requires = ['xattr', ],
     classifiers = ['Development Status :: 4 - Beta',
                    'License :: OSI Approved :: MIT License',
                    'Intended Audience :: Developers',


### PR DESCRIPTION
xattr is defined in install_requires=[], as it may not be present.

moved "from xattr import xattr" inside __main__ so that import __version__ works during setup, even if xattr is not installed.